### PR TITLE
Resolved issue where Slash Command wasn't registering.

### DIFF
--- a/HubitatBot/Commands/PingCommand.cs
+++ b/HubitatBot/Commands/PingCommand.cs
@@ -1,8 +1,14 @@
+using System.ComponentModel;
 using DSharpPlus.Commands;
+using DSharpPlus.Commands.Processors.SlashCommands;
+using DSharpPlus.Entities;
 namespace HubitatBot;
 
 public class PingCommand
 {
     [Command("ping")]
+    [Description("Slash command to test bot response time.")]
+    [DSharpPlus.Commands.Trees.Metadata.AllowedProcessors(typeof(SlashCommandProcessor))]
+    [SlashCommandTypes(DiscordApplicationCommandType.SlashCommand)]
     public static ValueTask ExecuteAsync(CommandContext context) => context.RespondAsync($"Pong! Latency is {context.Client.Ping}ms.");
 }

--- a/HubitatBot/Services/HubitatBotService.cs
+++ b/HubitatBot/Services/HubitatBotService.cs
@@ -4,7 +4,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Configuration;
 using DSharpPlus;
 using DSharpPlus.Commands;
-using DSharpPlus.Commands.Processors.TextCommands;
 using DSharpPlus.Commands.Processors.SlashCommands;
 
 namespace HubitatBot;
@@ -40,9 +39,8 @@ public sealed class HubitatBotService : IHostedService
             DebugGuildId = this._config.GetValue<ulong>("Bot:Debug_Guild_Id", 0),
             ServiceProvider = this._serviceProvider,
         });
-        await extension.AddProcessorAsync(new TextCommandProcessor());
         await extension.AddProcessorAsync(new SlashCommandProcessor());
-        extension.AddCommands(currentAssembly);
+        extension.AddCommands(currentAssembly, this._config.GetValue<ulong>("Bot:Debug_Guild_Id", 0));
 
         // Start Discord Bot connection.
         await _discordClient.ConnectAsync();


### PR DESCRIPTION
When attempting to register new Slash Commands it can take Discord a few hours to update. This doesn't work in a dev environment and the way to resolve it was to register new commands to a specific Discord server by specifying a Guild Id.